### PR TITLE
fix-flaky test createRequestBuilder

### DIFF
--- a/core/src/test/java/org/jsmart/zerocode/core/httpclient/BasicHttpClientTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/httpclient/BasicHttpClientTest.java
@@ -25,6 +25,8 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 public class BasicHttpClientTest {
     private BasicHttpClient basicHttpClient;
@@ -47,7 +49,8 @@ public class BasicHttpClientTest {
         RequestBuilder requestBuilder = basicHttpClient.createRequestBuilder("/api/v1/founder", "POST", header, reqBodyAsString);
         String nameValuePairString = EntityUtils.toString(requestBuilder.getEntity(), "UTF-8");
         assertThat(requestBuilder.getMethod(), is("POST"));
-        assertThat(nameValuePairString, is("Company=Amazon&worthInBillion=999.999&age=30"));
+        String sortedNameValuePairString = Arrays.stream(nameValuePairString.split("&")).sorted().collect(Collectors.joining("&"));
+        assertThat(sortedNameValuePairString, is("Company=Amazon&age=30&worthInBillion=999.999"));
     }
 
     @Test


### PR DESCRIPTION
# <Feature Title>

## Fixes Issue
- [ ] Which issue or ticket was(will be) fixed by this PR? (capture the issue number)
Fixes test - org.jsmart.zerocode.core.httpclient.BasicHttpClientTest.createRequestBuilder

PR Branch
**_#ADD LINK TO THE PR BRANCH_**

## Motivation and Context

Fixed a testcase that was failing due to "non-deterministic order", identified using the "NonDex" tool. NonDex is a tool for detecting and debugging wrong assumptions on under-determined Java APIs. An example of such an assumption is when code assumes the order of iteration through the entries in a java.util.HashMap is deterministic , while the [specification](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html) for java.util.HashMap states that its iteration order is not guaranteed to be in any particular order. 
Tool Reference : https://github.com/TestingResearchIllinois/NonDex

Steps to reproduce test-failure:
mvn -pl core/ edu.illinois:nondex-maven-plugin:2.1.7:nondex test -Dtest=org.jsmart.zerocode.core.httpclient.BasicHttpClientTest#createRequestBuilder 

Failure Log:
Expected: is "Company=Amazon&worthInBillion=999.999&age=30"
     but: was "Company=Amazon&age=30&worthInBillion=999.999"

Fix: 
Splitting the string on "&", sorting and comparing the strings. Eliminating the flakiness of the testcase.


## Checklist:

* [ ] New Unit tests were added
  * [ ] Covered in existing Unit tests

* [ ] Integration tests were added
  * [ ] Covered in existing Integration tests

* [ ] Test names are meaningful

* [ ] Feature manually tested and outcome is successful

* [ ] PR doesn't break any of the earlier features for end users
  * [ ] WARNING! This might break one or more earlier earlier features, hence left a comment tagging all reviewrs

* [ ] Branch build passed in CI

* [ ] No 'package.*' in the imports

* [ ] Relevant DOcumentation page added or updated with clear instructions and examples for the end user
  * [x] Not applicable. This was only a code refactor change, no functional or behaviourial changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
